### PR TITLE
Hotfix/maintenance 20201127

### DIFF
--- a/backup-tasks.gemspec
+++ b/backup-tasks.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/backup-tasks.gemspec
+++ b/backup-tasks.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler"
   spec.add_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/backup/tasks/backup.rake
+++ b/lib/backup/tasks/backup.rake
@@ -25,7 +25,7 @@ namespace :backup do
       dump_file = File.join(BACKUP_DIR, "#{db['database']}.dump")
       sql_file = File.join(BACKUP_DIR, "#{db['database']}.sql")
       system(
-        "mysqldump -u #{db['username']} #{"-p'#{db['password']}'" if db['password']} #{db['database']} > #{dump_file}"
+        "mysqldump  --no-tablespaces -u #{db['username']} #{"-p'#{db['password']}'" if db['password']} #{db['database']} > #{dump_file}"
       )
       File.open(sql_file, 'w') { |f| f.puts "use #{db['database']};\n" }
       system("cat #{dump_file} >> #{sql_file}")

--- a/lib/backup/tasks/backup.rake
+++ b/lib/backup/tasks/backup.rake
@@ -21,6 +21,20 @@ namespace :backup do
     args.map { |name, value| [name, value].join('=') }.join(' ')
   end
 
+  def dumpfile_path(backup_dir: BACKUP_DIR)
+    default_path = File.join(backup_dir, 'database.dump')
+
+    # when restoring from a current tarball the default dumpfile should exist
+    return default_path if File.exist?(default_path)
+
+    # when restoring from an old tarball the default dumpfile may be named differently
+    legacy_path = Dir.glob(File.join(backup_dir, '*.dump')).first
+    return legacy_path if legacy_path.present?
+
+    # when creating a tarball return the default dumpfile
+    default_path
+  end
+
   desc 'Create backup of rails application data'
   task :create do
     FileUtils.rm_r(BACKUP_DIR) if File.directory?(BACKUP_DIR)
@@ -32,15 +46,9 @@ namespace :backup do
 
       db = Rails.configuration.database_configuration[Rails.env]
 
-      dump_file = File.join(BACKUP_DIR, "#{db['database']}.dump")
-      sql_file = File.join(BACKUP_DIR, "#{db['database']}.sql")
-
       system(
-        "mysqldump --no-tablespaces #{mysqldump_database_args(db)} #{db['database']} > #{dump_file}"
+        "mysqldump --no-tablespaces #{mysqldump_database_args(db)} #{db['database']} > #{dumpfile_path}"
       )
-
-      File.open(sql_file, 'w') { |f| f.puts "use #{db['database']};\n" }
-      system("cat #{dump_file} >> #{sql_file}")
     end
 
     # backup uploads
@@ -89,7 +97,13 @@ namespace :backup do
     confirmation = STDIN.gets.strip
     abort 'Aborted' unless confirmation == 'Y'
 
+    # extract tarball and find out directory name
+    files_before = Dir.glob(File.join(File.dirname(BACKUP_DIR), '*'))
     system("tar -C #{File.dirname(BACKUP_DIR)} -xf #{tar_file}")
+    files_after = Dir.glob(File.join(File.dirname(BACKUP_DIR), '*'))
+
+    backup_dir = (files_after - files_before).first
+    abort "Could not determine backup directory. Maybe an old backup is still present?" unless backup_dir.present?
 
     # restore mysql database
     puts 'Restoring MySQL database...'
@@ -99,19 +113,21 @@ namespace :backup do
 
     db = Rails.configuration.database_configuration[Rails.env]
 
-    sql_file = File.join(BACKUP_DIR, "#{db['database']}.sql")
     system(
-      "mysql #{mysqldump_database_args(db)} < #{sql_file}"
+      "mysql #{mysqldump_database_args(db)} #{db['database']} < #{dumpfile_path(backup_dir: backup_dir)}"
+    )
+    system(
+      "bin/rails db:environment:set RAILS_ENV=#{Rails.env}"
     )
 
     # restore uploads
     src_dirs = [
-      File.join(BACKUP_DIR, 'public', 'uploads'),
-      File.join(BACKUP_DIR, 'private', 'uploads')
+      File.join(backup_dir, 'public', 'uploads'),
+      File.join(backup_dir, 'private', 'uploads')
     ]
 
     src_dirs.each do |src_dir|
-      dst_dir = File.join(Rails.root, src_dir[(BACKUP_DIR.length + 1)..-1])
+      dst_dir = File.join(Rails.root, src_dir[(backup_dir.length + 1)..-1])
 
       unless File.exist?(src_dir)
         puts "No backups found for #{dst_dir}. Skipped."
@@ -133,6 +149,6 @@ namespace :backup do
     end
 
     # cleanup
-    FileUtils.rm_r(BACKUP_DIR)
+    FileUtils.rm_r(backup_dir)
   end
 end


### PR DESCRIPTION
please review: @shanehofstetter 

* mysqldump verwendet "--no-tablespaces" um Fehlermeldung bei Dump zu beheben
* Unterstützung für Host/Port Datenbankverbindung mit mysqldump 
* Ermöglicht problemloses Verwenden von Tarballs aus anderen Rails Environments
* Korrigiert potentielles Sicherheitsproblem CVE-2020-8130